### PR TITLE
Dependency updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 image: Visual Studio 2017
 build_script:
-- ps: ./Build.ps1 -majorMinor "1.0" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- ps: ./Build.ps1 -majorMinor "2.0" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: SerilogWeb.*.nupkg
 deploy:

--- a/src/SerilogWeb.Classic.Mvc/SerilogWeb.Classic.Mvc.csproj
+++ b/src/SerilogWeb.Classic.Mvc/SerilogWeb.Classic.Mvc.csproj
@@ -41,12 +41,10 @@
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Serilog.2.7.1\lib\net45\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="SerilogWeb.Classic, Version=4.2.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SerilogWeb.Classic.4.2.41\lib\net45\SerilogWeb.Classic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SerilogWeb.Classic, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SerilogWeb.Classic.5.0.48\lib\net45\SerilogWeb.Classic.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SerilogWeb.Classic.Mvc/SerilogWeb.Classic.Mvc.nuspec
+++ b/src/SerilogWeb.Classic.Mvc/SerilogWeb.Classic.Mvc.nuspec
@@ -7,7 +7,7 @@
     <description>Adds ASP.NET MVC enrichers to SerilogWeb.Classic</description>
     <language>en-US</language>
     <projectUrl>https://github.com/serilog-web/classic-mvc</projectUrl>
-    <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <license type="expression">Apache-2.0</license>
     <iconUrl>https://serilog-web.github.io/pages/images/serilog-web.png</iconUrl>
     <tags>serilog logging aspnet mvc</tags>
   </metadata>

--- a/src/SerilogWeb.Classic.Mvc/packages.config
+++ b/src/SerilogWeb.Classic.Mvc/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Serilog" version="2.6.0" targetFramework="net45" />
-  <package id="SerilogWeb.Classic" version="4.2.41" targetFramework="net45" />
+  <package id="Serilog" version="2.7.1" targetFramework="net45" />
+  <package id="SerilogWeb.Classic" version="5.0.48" targetFramework="net45" />
 </packages>

--- a/test/SerilogWeb.Classic.Mvc.Test/SerilogWeb.Classic.Mvc.Test.csproj
+++ b/test/SerilogWeb.Classic.Mvc.Test/SerilogWeb.Classic.Mvc.Test.csproj
@@ -61,8 +61,7 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Serilog.2.7.1\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Settings.AppSettings.2.1.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
@@ -71,9 +70,8 @@
     <Reference Include="Serilog.Sinks.Trace, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.Trace.2.1.0\lib\net45\Serilog.Sinks.Trace.dll</HintPath>
     </Reference>
-    <Reference Include="SerilogWeb.Classic, Version=4.2.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SerilogWeb.Classic.4.2.41\lib\net45\SerilogWeb.Classic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SerilogWeb.Classic, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SerilogWeb.Classic.5.0.48\lib\net45\SerilogWeb.Classic.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/test/SerilogWeb.Classic.Mvc.Test/packages.config
+++ b/test/SerilogWeb.Classic.Mvc.Test/packages.config
@@ -15,9 +15,9 @@
   <package id="Modernizr" version="2.6.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
-  <package id="Serilog" version="2.6.0" targetFramework="net45" />
+  <package id="Serilog" version="2.7.1" targetFramework="net45" />
   <package id="Serilog.Settings.AppSettings" version="2.1.2" targetFramework="net45" />
   <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net45" />
-  <package id="SerilogWeb.Classic" version="4.2.41" targetFramework="net45" />
+  <package id="SerilogWeb.Classic" version="5.0.48" targetFramework="net45" />
   <package id="WebGrease" version="1.5.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Now referencing latest version of _SerilogWeb.Classic_ and a more recent version of Serilog , to have version matches across all the SerilogWeb packages.